### PR TITLE
Use wget instead of curl to download MS apt repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.python-version
 venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,8 @@ RUN set -eux; \
         python3 \
         python3-pip \
         wget \
-    ;
+    ; \
     # add MS apt repo
-RUN set -eux; \
     REPO_DEB="/tmp/packages-microsoft-prod.deb"; \
     wget -q https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb \
         -O "${REPO_DEB}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,9 @@ RUN set -eux; \
         locales \
         python3 \
         python3-pip \
-    ; \
+    ;
     # add MS apt repo
+RUN set -eux; \
     REPO_DEB="/tmp/packages-microsoft-prod.deb"; \
     curl -fsSL -o "${REPO_DEB}" \
         https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux; \
     # add MS apt repo
 RUN set -eux; \
     REPO_DEB="/packages-microsoft-prod.deb"; \
-    wget -https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb \
+    wget -q https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb \
         -O "${REPO_DEB}"; \
     dpkg -i "${REPO_DEB}"; \
     rm "${REPO_DEB}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -eux; \
     $AG install \
         apt-transport-https \
         build-essential \
-        curl \
+        wget \
         debconf-utils \
         gnupg2 \
         locales \
@@ -33,8 +33,8 @@ RUN set -eux; \
     # add MS apt repo
 RUN set -eux; \
     REPO_DEB="/tmp/packages-microsoft-prod.deb"; \
-    curl -fsSL -o "${REPO_DEB}" \
-        https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb; \
+    wget -https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb \
+        -O "${REPO_DEB}"; \
     dpkg -i "${REPO_DEB}"; \
     rm "${REPO_DEB}"; \
     # install SQL Server drivers and tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN set -eux; \
     ;
     # add MS apt repo
 RUN set -eux; \
-    REPO_DEB="/tmp/packages-microsoft-prod.deb"; \
+    REPO_DEB="/packages-microsoft-prod.deb"; \
     wget -https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb \
         -O "${REPO_DEB}"; \
     dpkg -i "${REPO_DEB}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,16 @@ RUN set -eux; \
     $AG install \
         apt-transport-https \
         build-essential \
-        wget \
         debconf-utils \
         gnupg2 \
         locales \
         python3 \
         python3-pip \
+        wget \
     ;
     # add MS apt repo
 RUN set -eux; \
-    REPO_DEB="/packages-microsoft-prod.deb"; \
+    REPO_DEB="/tmp/packages-microsoft-prod.deb"; \
     wget -q https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb \
         -O "${REPO_DEB}"; \
     dpkg -i "${REPO_DEB}"; \


### PR DESCRIPTION
There is a bug using curl on Ubuntu 24.04 Arm64 resulting in an `OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection` error. Example issue: https://github.com/curl/curl/issues/14154#issuecomment-2609793283
Since there is no need to upload any resources, wget can be used as a workaround.